### PR TITLE
Remove --no-deamon from gradle invocations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,13 +36,13 @@ runs:
     steps:
         - name: Check for new versions
           shell: bash
-          run: ./gradlew --no-daemon checkNewVersions
+          run: ./gradlew checkNewVersions
         - name: Apply version updates
           shell: bash
-          run: ./gradlew --no-daemon updateVersionsProps updatePlugins updateGradleWrapper
+          run: ./gradlew updateVersionsProps updatePlugins updateGradleWrapper
         - name: Write lockfile
           shell: bash
-          run: ./gradlew --no-daemon --write-locks
+          run: ./gradlew --write-locks
         - name: Create branch and commit changes
           shell: bash
           run: |


### PR DESCRIPTION
Gradle will always spin up a deamon since the non daemon mode got remove couple major versions ago. With that flag gradle will though shutdown the daemon at the end of the execution which incurs extra overhead in case of this action as it runs gradle 3 times. Without the flag we will spin up a daemon on first run and latter two will get to reuse it