### PR TITLE
Allow users to add a label onto update PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
         gh pr edit --body "${BODY}"
         if [ -n "${{ inputs.label }}" ];
         then
-          gh pr --label "${{ inputs.label }}"
+          gh pr edit --add-label "${{ inputs.label }}"
         fi
       env:
         GITHUB_TOKEN: "${{ inputs.push-to-repo-token }}"

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,8 @@ inputs:
     description: the title to use for the PR
     required: true
     default: Auto-update dependencies and plugins
+  label:
+    description: The name of a label to add to the PR
 
 runs:
   using: composite
@@ -77,5 +79,9 @@ runs:
 
         # update the PR body to set versions if different than creation
         gh pr edit --body "${BODY}"
+        if [ -n "${{ inputs.label }}" ];
+        then
+          gh pr --label "${{ inputs.label }}"
+        fi
       env:
         GITHUB_TOKEN: "${{ inputs.push-to-repo-token }}"


### PR DESCRIPTION
## Before this PR
It was not easy to add a label onto opened Update PRs. This was important for me because our github automation uses labels to determine when a PR should be automatically merged or not, which resulted in having to take a manual action to merge each update PR that is opened

## After this PR
Allow users to add a label onto update PRs

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
